### PR TITLE
[Content] Appendix C: 参考文献・リンクの拡充

### DIFF
--- a/docs/appendix/C-references.md
+++ b/docs/appendix/C-references.md
@@ -21,12 +21,37 @@ next: /chapters/
 - 『単体テストの考え方/使い方』
 - 『ユーザのための要件定義ガイド 第2版』
 
+補足:
+
+- 書籍は版（初版/改訂）によって内容が変わることがあります。参照時点での版を明記すると、チーム内の認識差を減らせます。
+
 ## テスト/ツール（公式）
 
 - Vitest: https://vitest.dev/
 - Jest: https://jestjs.io/
 - Playwright: https://playwright.dev/
 - MSW（Mock Service Worker）: https://mswjs.io/
+
+## 設計・境界・意思決定（公式/一次情報）
+
+- ADR（Documenting Architecture Decisions）: https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions
+- Hexagonal Architecture（Ports and Adapters）: https://alistair.cockburn.us/hexagonal-architecture/
+
+## テスト戦略（一次情報）
+
+- The Practical Test Pyramid: https://martinfowler.com/articles/practical-test-pyramid.html
+
+## 要件記述（一次情報）
+
+- RFC 2119（MUST/SHOULD などの用語）: https://www.rfc-editor.org/rfc/rfc2119
+
+## セキュリティ（公式）
+
+- OWASP ASVS: https://owasp.org/www-project-application-security-verification-standard/
+
+## 観測性/運用（公式）
+
+- OpenTelemetry: https://opentelemetry.io/
 
 ## GitHub Pages / Jekyll（公式）
 


### PR DESCRIPTION
Closes #20

## 変更点
- Appendix C に一次情報（ADR/Hexagonal/Test Pyramid/RFC2119/OWASP ASVS/OpenTelemetry）を追加

## 確認
- 追加URLは `curl -L` で `200` 応答を確認
- scripts/check_internal_links.py / markdownlint-cli2 はローカルで通過