### PR TITLE
[Content] Appendix E: 用語集（Glossary）の追加

### DIFF
--- a/docs/appendix/C-references.md
+++ b/docs/appendix/C-references.md
@@ -2,7 +2,7 @@
 title: "Appendix C: 参考文献・リンク"
 permalink: /appendix/C-references/
 show_nav: true
-prev: /appendix/D-samples/
+prev: /appendix/E-glossary/
 next: /chapters/
 ---
 
@@ -66,4 +66,4 @@ next: /chapters/
 ## 前後リンク
 
 - [目次]({{ '/chapters/' | relative_url }})
-- [前: Appendix D（記入例）]({{ '/appendix/D-samples/' | relative_url }})
+- [前: Appendix E（用語集）]({{ '/appendix/E-glossary/' | relative_url }})

--- a/docs/appendix/D-samples.md
+++ b/docs/appendix/D-samples.md
@@ -3,7 +3,7 @@ title: "Appendix D: 記入例（ランニング例の完成形）"
 permalink: /appendix/D-samples/
 show_nav: true
 prev: /appendix/B-templates/
-next: /appendix/C-references/
+next: /appendix/E-glossary/
 ---
 
 # Appendix D: 記入例（ランニング例の完成形）
@@ -168,4 +168,4 @@ Appendix B のテンプレを、ランニング例（小規模タスク管理）
 
 - [目次]({{ '/chapters/' | relative_url }})
 - [前: Appendix B（テンプレ集）]({{ '/appendix/B-templates/' | relative_url }})
-- [次: Appendix C（参考文献・リンク）]({{ '/appendix/C-references/' | relative_url }})
+- [次: Appendix E（用語集）]({{ '/appendix/E-glossary/' | relative_url }})

--- a/docs/appendix/E-glossary.md
+++ b/docs/appendix/E-glossary.md
@@ -1,0 +1,69 @@
+---
+title: "Appendix E: 用語集"
+permalink: /appendix/E-glossary/
+show_nav: true
+prev: /appendix/D-samples/
+next: /appendix/C-references/
+---
+
+# Appendix E: 用語集
+
+本書で繰り返し登場する用語を、最小の定義として整理します。厳密な学術定義ではなく、本書の判断（要件→設計→テスト）を揃えるための用語集です。
+
+## E-1. 要件/合意
+
+- **要求**: 利害関係者が「したいこと」。未整理で矛盾を含み得る
+  - 関連: [01. 要件定義を設計入力にする]({{ '/chapters/01-requirements-as-input/' | relative_url }})
+- **要件**: 合意され、検証可能な形に落とした要求（受け入れ条件を含む）
+  - 関連: [01. 要件定義を設計入力にする]({{ '/chapters/01-requirements-as-input/' | relative_url }})
+- **受け入れ条件**: 検証可能な合否基準（Given/When/Then など）
+  - 関連: [Appendix B: テンプレ集]({{ '/appendix/B-templates/' | relative_url }})
+- **非機能（NFR）**: 性能、可用性、セキュリティ、運用性などの制約条件
+  - 関連: [01. 要件定義を設計入力にする]({{ '/chapters/01-requirements-as-input/' | relative_url }})
+- **価値導線**: ユーザー価値を成立させる主要な利用フロー（止まると損失が大きい導線）
+  - 関連: [06. テスト戦略（単体/統合/E2E）]({{ '/chapters/06-test-strategy-pyramid/' | relative_url }})
+
+## E-2. 設計/境界
+
+- **相互作用**: ある変更が別の箇所に波及する関係（暗黙依存を含む）
+  - 関連: [02. 複雑性の捉え方]({{ '/chapters/02-complexity-and-interaction/' | relative_url }})
+- **境界**: 依存方向を固定し、相互作用を制御する線引き（責務分離点）
+  - 関連: [04. 小規模TS向けの最小アーキテクチャ]({{ '/chapters/04-minimal-architecture-ts/' | relative_url }})
+- **契約**: 境界を跨ぐ入出力・失敗時の扱い・互換性などの合意（文書/型/テストで固定する）
+  - 関連: [05. 設計時にテストを織り込む]({{ '/chapters/05-design-for-testability/' | relative_url }})
+- **S/D/V**: 結合を扱うための物差し（統合強度 / 距離 / 変動性）
+  - 関連: [03. 結合の物差し（S/D/V）]({{ '/chapters/03-coupling-balance-sdv/' | relative_url }})
+- **Functional core / Thin shell**: 副作用のないコアと、I/O を担うシェルの分離方針
+  - 関連: [04. 小規模TS向けの最小アーキテクチャ]({{ '/chapters/04-minimal-architecture-ts/' | relative_url }})
+- **adapter**: DB/HTTP/外部I/F などの I/O を担う実装（境界の外側）
+  - 関連: [04. 小規模TS向けの最小アーキテクチャ]({{ '/chapters/04-minimal-architecture-ts/' | relative_url }})
+- **port**: adapter を抽象化した「依存先インターフェース」（ユースケース側が引数で受ける）
+  - 関連: [05. 設計時にテストを織り込む]({{ '/chapters/05-design-for-testability/' | relative_url }})
+
+## E-3. テスト
+
+- **単体テスト**: 小さい単位（関数/モジュール）で振る舞い（契約）を検証する
+  - 関連: [06. テスト戦略（単体/統合/E2E）]({{ '/chapters/06-test-strategy-pyramid/' | relative_url }})
+- **統合テスト**: 境界を跨ぐ契約（DB/HTTP/認可/外部連携）を検証する
+  - 関連: [05. 設計時にテストを織り込む]({{ '/chapters/05-design-for-testability/' | relative_url }})
+- **E2E**: ユーザー導線として価値を提供できることを検証する（少数精鋭）
+  - 関連: [06. テスト戦略（単体/統合/E2E）]({{ '/chapters/06-test-strategy-pyramid/' | relative_url }})
+- **モック/スタブ**: 外部依存を代替し、制御可能にする手段（境界に寄せる）
+  - 関連: [05. 設計時にテストを織り込む]({{ '/chapters/05-design-for-testability/' | relative_url }})
+- **フレーク**: 非決定性（時刻/データ/外部I/O/待機）により、テスト結果が不安定になること
+  - 関連: [06. テスト戦略（単体/統合/E2E）]({{ '/chapters/06-test-strategy-pyramid/' | relative_url }})
+
+## E-4. 意思決定/運用
+
+- **ADR**: Architecture Decision Record（意思決定の記録）
+  - 関連: [07. 進化条件（ADRと境界の強化タイミング）]({{ '/chapters/07-evolution-and-adr/' | relative_url }})
+- **Change Drivers**: 「なぜ今変えるか」を整理するドライバー（S/D/V、運用要件、組織等）
+  - 関連: [Appendix B: テンプレ集]({{ '/appendix/B-templates/' | relative_url }})
+- **観測性**: 期待する結果が、テスト・ログ・メトリクス等で確実に検証できる性質
+  - 関連: [05. 設計時にテストを織り込む]({{ '/chapters/05-design-for-testability/' | relative_url }})
+
+## 前後リンク
+
+- [目次]({{ '/chapters/' | relative_url }})
+- [前: Appendix D（記入例）]({{ '/appendix/D-samples/' | relative_url }})
+- [次: Appendix C（参考文献・リンク）]({{ '/appendix/C-references/' | relative_url }})

--- a/docs/chapters/TOC.md
+++ b/docs/chapters/TOC.md
@@ -25,4 +25,5 @@ permalink: /chapters/
 - [Appendix A: チェックリスト]({{ '/appendix/A-checklists/' | relative_url }})
 - [Appendix B: テンプレ集]({{ '/appendix/B-templates/' | relative_url }})
 - [Appendix D: 記入例（ランニング例の完成形）]({{ '/appendix/D-samples/' | relative_url }})
+- [Appendix E: 用語集]({{ '/appendix/E-glossary/' | relative_url }})
 - [Appendix C: 参考文献・リンク]({{ '/appendix/C-references/' | relative_url }})


### PR DESCRIPTION
Closes #22

## 変更点
- `docs/appendix/E-glossary.md` を追加（本書の主要用語を集約）
- Appendix の前後リンクを調整（D→E→C）
- `docs/chapters/TOC.md` に Appendix E を追加

## ローカル検証
- scripts/check_internal_links.py
- markdownlint-cli2