### PR TITLE
[Repo] Issue #62: book-config.json運用ルールとCI検証

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Validate book-config.json
+        run: python3 -c "import json; json.load(open('book-config.json', 'r', encoding='utf-8')); print('book-config.json OK')"
+
       - name: Internal links (permalink/nav)
         run: python3 scripts/check_internal_links.py
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,3 +32,13 @@
 - 「判断基準（S/D/V、テスト戦略、非機能の最小合意）」を中心に据える
 - フレームワーク固有の実装最適化は原則扱わない（必要なら別 Issue で合意）
 - コード例は短くし、境界・依存・型が伝わることを優先する
+
+## book-config.json（シリーズ横展開用メタデータ）
+
+`book-config.json` は、シリーズ書籍の横展開・機械処理（book-formatter）で利用するメタデータです。
+
+- 章/付録の追加・並び替えを行う場合は、以下を同期してください
+  - `docs/_data/navigation.yml`（前後ナビの順序）
+  - `docs/_includes/sidebar-nav.html`（サイドバーの章/付録表示）
+  - `book-config.json`（`structure.chapters` / `structure.appendices`）
+- タイトル/説明/著者/バージョンを変更する場合は、`docs/_config.yml` と `book-config.json` の整合も確認してください

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 
 ## ディレクトリ構成（概要）
 
+- `book-config.json`: シリーズ横展開/機械処理向けのメタデータ（book-formatter 用）
 - `docs/index.md`: トップページ
 - `docs/chapters/`: 章（`TOC.md` を含む）
 - `docs/appendix/`: 付録（チェックリスト、テンプレ、参考文献）


### PR DESCRIPTION
## 変更内容

- `README.md` に `book-config.json`（シリーズ横展開/機械処理用メタデータ）の説明を追加
- `CONTRIBUTING.md` に `book-config.json` の更新ルール（navigation/sidebarとの同期）を追記
- CI（Link check job）に `book-config.json` のJSON構文チェックを追加

## 対象 Issue

- Closes #62

## チェックリスト（必須）

- [ ] CI が通っている
