### PR TITLE
[Content] Issue #65: トップページに目次（本編/Appendix）を表示

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -49,16 +49,20 @@ permalink: /
 
 ### 本編
 
+<ul>
 {% for item in nav.chapters %}
 {% unless item.path == '/chapters/' %}
-- [{{ item.title }}]({{ item.path | relative_url }})
+  <li><a href="{{ item.path | relative_url }}">{{ item.title }}</a></li>
 {% endunless %}
 {% endfor %}
+</ul>
 
 ### Appendix
 
+<ul>
 {% for item in nav.appendices %}
-- [{{ item.title }}]({{ item.path | relative_url }})
+  <li><a href="{{ item.path | relative_url }}">{{ item.title }}</a></li>
 {% endfor %}
+</ul>
 
 補足: 一覧ページとして [目次]({{ '/chapters/' | relative_url }}) も用意しています。


### PR DESCRIPTION
## 変更内容

- `docs/index.md` に「目次」セクションを追加し、`docs/_data/navigation.yml` から本編/Appendixのリンク一覧を生成
- 既存の「読み方」からの導線と整合

## 対象 Issue

- Closes #65

## チェックリスト（必須）

- [ ] CI が通っている
