### PR TITLE
[Content] Issue #73: API契約テンプレ（B-14/D-22）を追加

### DIFF
--- a/docs/chapters/04-minimal-architecture-ts.md
+++ b/docs/chapters/04-minimal-architecture-ts.md
@@ -101,6 +101,8 @@ export type UsecaseError =
 
 - エラーコードカタログ（任意）: [Appendix B: テンプレ集（B-10）]({{ '/appendix/B-templates/' | relative_url }})
 - 記入例: [Appendix D: 記入例（D-18）]({{ '/appendix/D-samples/' | relative_url }})
+- API 契約（任意）: [Appendix B: テンプレ集（B-14）]({{ '/appendix/B-templates/' | relative_url }})
+- 記入例: [Appendix D: 記入例（D-22）]({{ '/appendix/D-samples/' | relative_url }})
 
 ### 依存方向のルール（禁止事項で固定する）
 

--- a/docs/chapters/05-design-for-testability.md
+++ b/docs/chapters/05-design-for-testability.md
@@ -52,6 +52,7 @@ next: /chapters/06-test-strategy-pyramid/
 - 小規模での線引き（現実解）:
   - DB は「実物」を使い、repository adapter 経由で検証する
   - ネットワーク越しの外部サービスは、統合テストでは直接叩かず、adapter の契約をテストダブルで固定する（フレーク源になりやすい）
+  - HTTP 入出力（入出力/エラー/冪等性）は API 契約として残すと、期待値（契約）が揃いやすい（任意: [Appendix B（B-14）]({{ '/appendix/B-templates/' | relative_url }}) / 記入例: [Appendix D（D-22）]({{ '/appendix/D-samples/' | relative_url }})）
 
 ## モック/スタブ方針（境界に寄せる）
 


### PR DESCRIPTION
## 変更内容

- `docs/appendix/B-templates.md` に B-14（API 契約テンプレ）を追加
- `docs/appendix/D-samples.md` に D-22（B-14の記入例）を追加
- 本文側の導線として、`docs/chapters/04-minimal-architecture-ts.md` と `docs/chapters/05-design-for-testability.md` から参照を追加

## 対象 Issue

- Closes #73

## チェックリスト（必須）

- [ ] CI が通っている
