### PR TITLE
Fix: 下部ナビの前へ/次へが章ページで誤解決される問題を修正

### DIFF
--- a/docs/_includes/page-navigation.html
+++ b/docs/_includes/page-navigation.html
@@ -91,16 +91,33 @@ display ToC titles even when order falls back to site.pages.
 {% endif %}
 
 {%- assign current_index = nil -%}
+{%- assign _best_match_len = 0 -%}
 {%- if nav_items and nav_items.size > 0 -%}
   {%- for item in nav_items -%}
-    {%- if item.path and item.path != '' -%}
-      {%- assign item_url = item.path -%}
-    {%- else -%}
-      {%- assign item_url = item.url -%}
+    {%- assign item_url = item.path | default: item.url -%}
+    {%- assign item_url_n = item_url -%}
+    {%- if _baseurl and _baseurl != '' -%}
+      {%- assign item_url_n = item_url_n | remove_first: _baseurl -%}
     {%- endif -%}
-    {%- if item_url == page.url or page.url contains item_url -%}
-      {%- assign current_index = forloop.index0 -%}
-      {%- break -%}
+
+    {%- assign item_len = item_url_n | size -%}
+
+    {%- comment -%}
+    Prefer the longest match to avoid prefix collisions (e.g., "/chapters/" matches "/chapters/00-.../").
+    {%- endcomment -%}
+    {%- if item_url_n == _page_url_n -%}
+      {%- if item_len > _best_match_len -%}
+        {%- assign _best_match_len = item_len -%}
+        {%- assign current_index = forloop.index0 -%}
+      {%- endif -%}
+    {%- else -%}
+      {%- if item_url_n != '/' -%}
+        {%- assign page_prefix = _page_url_n | slice: 0, item_len -%}
+        {%- if page_prefix == item_url_n and item_len > _best_match_len -%}
+          {%- assign _best_match_len = item_len -%}
+          {%- assign current_index = forloop.index0 -%}
+        {%- endif -%}
+      {%- endif -%}
     {%- endif -%}
   {%- endfor -%}
 {%- endif -%}


### PR DESCRIPTION
下部の「前へ/次へ」ナビが、章ページで誤ったページに解決される問題を修正します。

## 背景
`docs/_data/navigation.yml` に `/chapters/`（目次）が含まれているため、従来の判定ロジック（`page.url contains item_url`）だと `/chapters/00-.../` 等の章ページでも最初に `/chapters/` に一致してしまい、常に同じ「次へ」になっていました。

## 変更内容
- `docs/_includes/page-navigation.html` の現在ページ判定を「最長一致（最も具体的なURLを優先）」に変更
  - `/chapters/` と `/chapters/00-about-this-book/` のような prefix 衝突を回避

## 影響範囲
- 表示のみ（ページの内容やパスは変更なし）

