### PR TITLE
Issue #97: book-config license を SPDX 形式に統一

### DIFF
--- a/book-config.json
+++ b/book-config.json
@@ -4,7 +4,7 @@
   "author": "株式会社アイティードゥ",
   "version": "0.1.0",
   "language": "ja",
-  "license": "CC BY-NC-SA 4.0",
+  "license": "CC-BY-NC-SA-4.0",
   "repository": {
     "url": "https://github.com/itdojp/small-webapp-software-design-book.git",
     "branch": "main"


### PR DESCRIPTION
Issue #97（Issue #95 横展開）対応。\n\n- book-config.json の license を CC-BY-NC-SA-4.0（SPDX形式）に統一\n\n関連: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/97