### PR TITLE
chore: add Jekyll build + site smoke to Book QA

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pages: read
 
     steps:
       - name: Checkout book
@@ -53,6 +54,9 @@ jobs:
         run: node book-formatter/scripts/check-links.js "${{ steps.scan.outputs.dir }}"
 
 
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
       - name: Build (Jekyll; GitHub Pages compatible)
         uses: actions/jekyll-build-pages@v1
         with:
@@ -94,18 +98,33 @@ jobs:
             nav = scan_dir / "_data" / "navigation.yml"
             if not nav.exists():
               return []
-            data = yaml.safe_load(nav.read_text(encoding="utf-8")) or {}
+            try:
+              raw = nav.read_text(encoding="utf-8")
+              data = yaml.safe_load(raw) or {}
+            except yaml.YAMLError as e:
+              nav_display = nav
+              try:
+                nav_display = nav.relative_to(Path.cwd())
+              except ValueError:
+                pass
+              print(f"::error file={nav_display}::Failed to parse navigation YAML: {e}")
+              sys.exit(1)
             paths = []
+            # Keep this segment list broad to support different book structures.
             for key in ["introduction", "chapters", "additional", "resources", "appendices", "afterword"]:
               for item in (data.get(key) or []):
-                if isinstance(item, dict) and isinstance(item.get("items"), list):
-                  for sub in (item.get("items") or []):
-                    if not isinstance(sub, dict):
-                      continue
-                    p = normalize_path(sub.get("path"))
-                    if p:
-                      paths.append(p)
-                  continue
+                if isinstance(item, dict):
+                  nested = item.get("items")
+                  if not isinstance(nested, list):
+                    nested = item.get("children")
+                  if isinstance(nested, list):
+                    for sub in (nested or []):
+                      if not isinstance(sub, dict):
+                        continue
+                      p = normalize_path(sub.get("path"))
+                      if p:
+                        paths.append(p)
+                    continue
                 if not isinstance(item, dict):
                   continue
                 p = normalize_path(item.get("path"))
@@ -151,6 +170,7 @@ jobs:
             if lower.endswith((".html", ".htm", ".pdf", ".txt")):
               return [site_dir / rel]
             if lower.endswith(".md"):
+              # Jekyll usually converts Markdown to HTML, but Markdown without front matter may be copied as-is.
               html_rel = rel[:-3] + ".html"
               return [site_dir / rel, site_dir / html_rel]
             # Directory-like (pretty permalink)
@@ -173,7 +193,15 @@ jobs:
             "assets/js/search.js",
             "assets/js/code-copy-lightweight.js",
           ]
-          missing_assets = [a for a in required_assets if not (site_dir / a).exists()]
+          missing_assets = [
+            a
+            for a in required_assets
+            if not (
+              (site_dir / a).exists()
+              and (site_dir / a).is_file()
+              and (site_dir / a).stat().st_size > 0
+            )
+          ]
 
           if missing or missing_assets:
             if missing:

--- a/.github/workflows/nav-link-check.yml
+++ b/.github/workflows/nav-link-check.yml
@@ -19,18 +19,20 @@ jobs:
         id: build
         run: |
           python3 - << 'PY'
-          import os, yaml
+          import os, sys, yaml
           from pathlib import Path
           repo = os.environ.get('GITHUB_REPOSITORY','').split('/')[-1]
-          cfg = Path('docs/_config.yml') if Path('docs/_config.yml').exists() else Path('_config.yml')
+          base_dir = Path('docs') if Path('docs').is_dir() else Path('.')
+          cfg = base_dir / '_config.yml'
           baseurl = f'/{repo}'
           if cfg.exists():
               try:
                   data = yaml.safe_load(cfg.read_text(encoding='utf-8')) or {}
                   bu = data.get('baseurl')
                   if isinstance(bu,str) and bu.strip():
-                      baseurl = bu.strip().strip('"\'')
-              except Exception:
+                      baseurl = bu.strip().strip('"\'').strip()
+              except Exception as e:
+                  print(f"::warning file={cfg}::Failed to parse _config.yml as YAML; falling back to naive parse ({e})")
                   # Fallback to naive parse but strip quotes
                   for line in cfg.read_text(encoding='utf-8').splitlines():
                       if line.strip().startswith('baseurl:'):
@@ -58,21 +60,29 @@ jobs:
               return p if p.endswith('/') else p + '/'
 
           def read_nav():
-              y = Path('docs/_data/navigation.yml')
+              y = base_dir / '_data' / 'navigation.yml'
               if not y.exists(): return []
-              data = yaml.safe_load(y.read_text(encoding='utf-8')) or {}
+              try:
+                  data = yaml.safe_load(y.read_text(encoding='utf-8')) or {}
+              except yaml.YAMLError as e:
+                  print(f"::error file={y}::Failed to parse navigation YAML: {e}")
+                  sys.exit(1)
               paths = []
               for key in ['introduction','chapters','additional','resources','appendices','afterword']:
                   for item in (data.get(key) or []):
                       # Some books structure chapters as parts: {part, items:[{title,path},...]}
-                      if isinstance(item, dict) and isinstance(item.get('items'), list):
-                          for sub in (item.get('items') or []):
-                              if not isinstance(sub, dict):
-                                  continue
-                              p = normalize_path(sub.get('path'))
-                              if p:
-                                  paths.append(p)
-                          continue
+                      if isinstance(item, dict):
+                          nested = item.get('items')
+                          if not isinstance(nested, list):
+                              nested = item.get('children')
+                          if isinstance(nested, list):
+                              for sub in (nested or []):
+                                  if not isinstance(sub, dict):
+                                      continue
+                                  p = normalize_path(sub.get('path'))
+                                  if p:
+                                      paths.append(p)
+                              continue
                       if not isinstance(item, dict):
                           continue
                       p = normalize_path(item.get('path'))
@@ -82,7 +92,7 @@ jobs:
           def discover():
               paths=[]
               for seg in ['introduction','chapters','additional','resources','appendices','afterword']:
-                  d = Path('docs')/seg
+                  d = base_dir/seg
                   if d.is_dir():
                       for child in sorted(d.iterdir()):
                           if child.is_dir(): paths.append(f'/{seg}/{child.name}/')


### PR DESCRIPTION
Book QA に Jekyll ビルド + built-site スモークチェックを追加します。

- `actions/jekyll-build-pages@v1` で GitHub Pages 互換のビルドを実行
- `_site/` 出力に対して、トップ/ナビゲーション（`docs/_data/navigation.yml` またはディレクトリ構造）/共通アセットの存在を検証
- （該当する書籍のみ）`nav-link-check.yml` が未導入の場合、テンプレのワークフローを追加

関連:
- itdojp/it-engineer-knowledge-architecture#102
