### PR TITLE
chore: add PR template (QA/Pages checklist)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,24 +1,28 @@
-## 概要（必須）
+## 変更内容
 
-- 変更内容:
+-
 
-## 影響範囲（必須）
+## 対象 Issue
 
-- 対象章/ページ（例: /chapters/chapter01/）:
-- 影響（例: 追記 / 構成変更 / リンク修正 / 図表修正）:
+- Closes #
 
-## QA（必須）
+## チェックリスト（必須）
+
+- [ ] `STYLEGUIDE.md` の章テンプレ/見出しルールに適合している
+- [ ] 章間リンク（目次/前へ/次へ）が壊れていない
+- [ ] 引用/参考文献の扱いが `POLICY.md` に適合している（転載なし、引用最小）
+- [ ] CI が通っている（導入済みの場合）
 
 - [ ] Book QA（Unicode / textlint(PRH) / 内部リンク・アンカー / Jekyll build / built-site smoke）: PASS
-  - 実行URL:
+  - 実行URL: （GitHub Actions の workflow run URL）
 
-## Pages確認（原則必須）
+- [ ] Pages確認（原則必須）
+  - 確認URL: https://itdojp.github.io/small-webapp-software-design-book/ （fork/rename の場合は適宜読み替え）
+  - [ ] トップページ HTTP 200
+  - [ ] 主要導線（navigation.yml 相当）で 404 が無い
+  - [ ] 表示崩れが無い（図表/表/コード中心）
 
-- 確認URL: https://itdojp.github.io/small-webapp-software-design-book/
-- [ ] トップページ HTTP 200
-- [ ] 主要導線（navigation.yml 相当）で 404 が無い
-- [ ] 表示崩れが無い（図表/表/コード中心）
+## 補足（レビュー観点）
 
-## 補足
-
-- 既知の制約 / TODO:
+- 断定している箇所の前提（小規模/TS/Web）が明確か
+- 判断基準（S/D/V、非機能の最小合意、テスト配分）に接続しているか


### PR DESCRIPTION
https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102 Phase 3（PRテンプレ必須化）対応です。

- `.github/PULL_REQUEST_TEMPLATE.md` を追加/更新し、QA結果・Pages確認URL・影響範囲の記載を標準化

補足:
- 既存テンプレがあるリポジトリは、固有チェック項目を維持したまま必須項目（QA/Pages）を追記
