### PR TITLE
[codex] Harden metadata navigation quality gate

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -47,6 +47,9 @@ jobs:
             echo "dir=." >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Validate metadata and navigation consistency
+        run: python3 scripts/check_book_config_navigation_consistency.py
+
       - name: Unicode check (fail on warnings)
         run: node book-formatter/scripts/check-unicode.js "${{ steps.scan.outputs.dir }}" --allowlist .book-formatter/unicode-allowlist.json --fail-on warn
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Validate book-config.json
         run: python3 -c "import json; json.load(open('book-config.json', 'r', encoding='utf-8')); print('book-config.json OK')"
 
-      - name: Validate book-config.json <-> navigation.yml
+      - name: Validate metadata and navigation consistency
         run: python3 scripts/check_book_config_navigation_consistency.py
 
       - name: Internal links (permalink/nav)

--- a/README.md
+++ b/README.md
@@ -17,10 +17,18 @@
 
 ## CI（品質ゲート）
 
-- `.github/workflows/ci.yml` で以下を実行します
-  - Jekyll build（`bundle exec jekyll build --source docs --config docs/_config.yml`）
-  - Markdown lint（markdownlint）
-  - リンクチェック（内部: `scripts/check_internal_links.py` / 外部: lychee）
+ローカルで最小確認を行う場合は、次を実行します。
+
+- `python3 scripts/check_book_config_navigation_consistency.py`
+- `python3 scripts/check_internal_links.py`
+- `bundle exec jekyll build --source docs --config docs/_config.yml --destination _site`
+
+`.github/workflows/ci.yml` では以下を実行します。
+
+- Jekyll build（`bundle exec jekyll build --source docs --config docs/_config.yml`）
+- Markdown lint（markdownlint）
+- メタデータ/ナビゲーション整合性チェック（`scripts/check_book_config_navigation_consistency.py`）
+- リンクチェック（内部: `scripts/check_internal_links.py` / 外部: lychee）
 
 ## 読み方
 

--- a/book-config.json
+++ b/book-config.json
@@ -14,74 +14,88 @@
       {
         "id": "toc",
         "title": "目次",
-        "description": "本書の章構成と推奨読了順"
+        "description": "本書の章構成と推奨読了順",
+        "path": "/chapters/"
       },
       {
         "id": "chapter00",
         "title": "00. この本の使い方",
-        "description": "本書の適用範囲・非ゴール・判断原則を整理する"
+        "description": "本書の適用範囲・非ゴール・判断原則を整理する",
+        "path": "/chapters/00-about-this-book/"
       },
       {
         "id": "chapter01",
         "title": "01. 要件定義を設計入力にする",
-        "description": "要求を合意された要件へ変換し、設計入力として扱う"
+        "description": "要求を合意された要件へ変換し、設計入力として扱う",
+        "path": "/chapters/01-requirements-as-input/"
       },
       {
         "id": "chapter02",
         "title": "02. 複雑性の捉え方",
-        "description": "相互作用と複雑性の観点で設計の難所を言語化する"
+        "description": "相互作用と複雑性の観点で設計の難所を言語化する",
+        "path": "/chapters/02-complexity-and-interaction/"
       },
       {
         "id": "chapter03",
         "title": "03. 結合の物差し（統合強度×距離×変動性）",
-        "description": "結合（知識の共有）をS/D/Vで評価し、弱め方を選ぶ"
+        "description": "結合（知識の共有）をS/D/Vで評価し、弱め方を選ぶ",
+        "path": "/chapters/03-coupling-balance-sdv/"
       },
       {
         "id": "chapter04",
         "title": "04. 小規模TS向けの最小アーキテクチャ",
-        "description": "小規模前提で必要十分なアーキテクチャを設計する"
+        "description": "小規模前提で必要十分なアーキテクチャを設計する",
+        "path": "/chapters/04-minimal-architecture-ts/"
       },
       {
         "id": "chapter05",
         "title": "05. 設計時にテストを織り込む",
-        "description": "テスト容易性を設計判断として組み込む"
+        "description": "テスト容易性を設計判断として組み込む",
+        "path": "/chapters/05-design-for-testability/"
       },
       {
         "id": "chapter06",
         "title": "06. テスト戦略（単体/統合/E2E）",
-        "description": "変更容易性と価値導線を守るテスト配分を決める"
+        "description": "変更容易性と価値導線を守るテスト配分を決める",
+        "path": "/chapters/06-test-strategy-pyramid/"
       },
       {
         "id": "chapter07",
         "title": "07. 進化条件（ADRと境界の強化タイミング）",
-        "description": "進化条件を言語化し、設計を継続改善できる形にする"
+        "description": "進化条件を言語化し、設計を継続改善できる形にする",
+        "path": "/chapters/07-evolution-and-adr/"
       }
     ],
     "appendices": [
       {
         "id": "appendix-a",
         "title": "Appendix A: チェックリスト",
-        "description": "要求→要件→仕様→設計→テストを作業漏れなく進めるための最小チェックリスト"
+        "description": "要求→要件→仕様→設計→テストを作業漏れなく進めるための最小チェックリスト",
+        "path": "/appendix/A-checklists/"
       },
       {
         "id": "appendix-b",
         "title": "Appendix B: テンプレ集",
-        "description": "要求/要件/仕様/設計/テストの判断・合意を再利用可能な形式にするテンプレート集"
+        "description": "要求/要件/仕様/設計/テストの判断・合意を再利用可能な形式にするテンプレート集",
+        "path": "/appendix/B-templates/"
       },
       {
         "id": "appendix-d",
         "title": "Appendix D: 記入例（ランニング例の完成形）",
-        "description": "Appendix B のテンプレをランニング例に記入した完成形の例"
+        "description": "Appendix B のテンプレをランニング例に記入した完成形の例",
+        "path": "/appendix/D-samples/"
       },
       {
         "id": "appendix-e",
         "title": "Appendix E: 用語集",
-        "description": "本書で用いる用語（要求/要件/仕様/設計ほか）の最小定義"
+        "description": "本書で用いる用語（要求/要件/仕様/設計ほか）の最小定義",
+        "path": "/appendix/E-glossary/"
       },
       {
         "id": "appendix-c",
         "title": "Appendix C: 参考文献・リンク",
-        "description": "参照情報（一次情報/公式）へのリンク集（本文転載はしない）"
+        "description": "参照情報（一次情報/公式）へのリンク集（本文転載はしない）",
+        "path": "/appendix/C-references/"
       }
     ]
   },
@@ -108,5 +122,6 @@
   "shared": {
     "version": "3.2.2",
     "lastSync": "2026-02-04T23:01:36.022Z"
-  }
+  },
+  "homepage": "https://itdojp.github.io/small-webapp-software-design-book/"
 }

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,6 +3,8 @@ title: "要件から始めるソフトウェア設計（小規模TS Webアプリ
 description: "小〜中規模の TypeScript Web アプリを対象に、要件定義→設計→テストまでを一貫して学ぶ実践教材"
 author: "株式会社アイティードゥ"
 version: "0.1.0"
+license: "CC-BY-NC-SA-4.0"
+homepage: "https://itdojp.github.io/small-webapp-software-design-book/"
 lang: "ja"
 
 # GitHub Pages settings (Project Pages)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,8 @@
 ---
 title: "要件から始めるソフトウェア設計（小規模TS Webアプリの実践）"
+description: "小〜中規模の TypeScript Web アプリを対象に、要件定義→設計→テストまでを一貫して学ぶ実践教材"
+author: "株式会社アイティードゥ"
+version: "0.1.0"
 permalink: /
 ---
 

--- a/scripts/check_book_config_navigation_consistency.py
+++ b/scripts/check_book_config_navigation_consistency.py
@@ -6,6 +6,18 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+from urllib.parse import unquote
+
+
+REPOSITORY = "itdojp/small-webapp-software-design-book"
+CANONICAL_HOMEPAGE = "https://itdojp.github.io/small-webapp-software-design-book/"
+REQUIRED_ASSETS = [
+    "assets/css/main.css",
+    "assets/css/syntax-highlighting.css",
+    "assets/js/theme.js",
+    "assets/js/search.js",
+    "assets/js/code-copy-lightweight.js",
+]
 
 
 @dataclass(frozen=True)
@@ -14,16 +26,80 @@ class NavItem:
     path: str
 
 
+@dataclass(frozen=True)
+class Page:
+    path: Path
+    permalink: str
+    title: str | None
+
+
 SECTION_RE = re.compile(r"^(chapters|appendices):\s*$")
 TITLE_RE = re.compile(r"^\s*-\s*title:\s*(?P<value>.+?)\s*$")
 PATH_RE = re.compile(r"^\s*path:\s*(?P<value>.+?)\s*$")
+FRONT_MATTER_RE = re.compile(r"^---\r?\n(.*?)\r?\n---\r?\n", re.DOTALL)
+SCALAR_RE = re.compile(r"^(?P<key>[A-Za-z0-9_-]+):\s*(?P<value>.*?)\s*$")
 
 
-def unquote(value: str) -> str:
+class CheckError(ValueError):
+    pass
+
+
+def unquote_scalar(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
     value = value.strip()
     if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
         return value[1:-1]
     return value
+
+
+def parse_scalar_block(text: str) -> dict[str, str]:
+    data: dict[str, str] = {}
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or line[:1].isspace():
+            continue
+        match = SCALAR_RE.match(line)
+        if not match:
+            continue
+        data[match.group("key")] = str(unquote_scalar(match.group("value")))
+    return data
+
+
+def parse_front_matter(path: Path) -> dict[str, str]:
+    text = path.read_text(encoding="utf-8")
+    match = FRONT_MATTER_RE.match(text)
+    if not match:
+        return {}
+    return parse_scalar_block(match.group(1))
+
+
+def normalize_public_path(value: Any, *, source: str) -> str:
+    if not isinstance(value, str):
+        raise CheckError(f"{source}: path must be a string")
+    path = value.strip()
+    if not path:
+        raise CheckError(f"{source}: path must not be empty")
+    if path.startswith(("http://", "https://", "mailto:")):
+        raise CheckError(f"{source}: external paths are not allowed: {path!r}")
+    if "{{" in path or "}}" in path:
+        raise CheckError(f"{source}: Liquid expressions are not allowed in canonical paths")
+    if "#" in path or "?" in path:
+        raise CheckError(f"{source}: path must not include query or fragment: {path!r}")
+    if "\\" in path:
+        raise CheckError(f"{source}: path must use forward slashes: {path!r}")
+    if not path.startswith("/"):
+        path = "/" + path
+    decoded = unquote(path)
+    parts = [part for part in decoded.split("/") if part]
+    if any(part in (".", "..") for part in parts):
+        raise CheckError(f"{source}: path traversal is not allowed: {path!r}")
+    if "%2f" in path.lower() or "%5c" in path.lower():
+        raise CheckError(f"{source}: encoded path separators are not allowed: {path!r}")
+    lower = path.lower()
+    if path != "/" and not lower.endswith((".md", ".html", ".htm", ".pdf", ".txt", "/")):
+        path += "/"
+    return path
 
 
 def parse_navigation_yaml(text: str) -> dict[str, list[NavItem]]:
@@ -47,21 +123,27 @@ def parse_navigation_yaml(text: str) -> dict[str, list[NavItem]]:
 
         title_match = TITLE_RE.match(line)
         if title_match:
-            pending_title = unquote(title_match.group("value"))
+            pending_title = str(unquote_scalar(title_match.group("value")))
             continue
 
         path_match = PATH_RE.match(line)
         if path_match:
             if pending_title is None:
-                raise ValueError(f"navigation.yml:{lineno}: path without title")
+                raise CheckError(f"navigation.yml:{lineno}: path without title")
             data[current_section].append(
-                NavItem(title=pending_title, path=unquote(path_match.group("value")))
+                NavItem(
+                    title=pending_title,
+                    path=normalize_public_path(
+                        unquote_scalar(path_match.group("value")),
+                        source=f"navigation.yml:{lineno}",
+                    ),
+                )
             )
             pending_title = None
             continue
 
     if pending_title is not None:
-        raise ValueError("navigation.yml: title without path at end of file")
+        raise CheckError("navigation.yml: title without path at end of file")
 
     return data
 
@@ -70,91 +152,234 @@ def load_json(path: Path) -> Any:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def extract_titles(items: Any, *, label: str) -> list[str]:
+def require_str(mapping: dict[str, Any], key: str, *, source: str) -> str:
+    value = mapping.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise CheckError(f"{source}.{key} must be a non-empty string")
+    return value.strip()
+
+
+def collect_structure_items(items: Any, *, label: str) -> list[NavItem]:
     if not isinstance(items, list):
-        raise ValueError(f"book-config.json: structure.{label} must be a list")
-    titles: list[str] = []
+        raise CheckError(f"book-config.json: structure.{label} must be a list")
+    result: list[NavItem] = []
     for i, item in enumerate(items):
+        source = f"book-config.json: structure.{label}[{i}]"
         if not isinstance(item, dict):
-            raise ValueError(
-                f"book-config.json: structure.{label}[{i}] must be an object"
+            raise CheckError(f"{source} must be an object")
+        for key in ("id", "title", "description", "path"):
+            require_str(item, key, source=source)
+        result.append(
+            NavItem(
+                title=require_str(item, "title", source=source),
+                path=normalize_public_path(item.get("path"), source=f"{source}.path"),
             )
-        title = item.get("title")
-        if not isinstance(title, str) or not title:
-            raise ValueError(
-                f"book-config.json: structure.{label}[{i}].title must be a non-empty string"
-            )
-        titles.append(title)
-    return titles
+        )
+    return result
 
 
-def compare_ordered_titles(
-    *, label: str, book_titles: list[str], nav_titles: list[str]
+def compare_ordered_items(
+    *, label: str, book_items: list[NavItem], nav_items: list[NavItem]
 ) -> list[str]:
     errors: list[str] = []
 
-    if len(book_titles) != len(nav_titles):
+    if len(book_items) != len(nav_items):
         errors.append(
-            f"{label}: count mismatch (book-config={len(book_titles)}, navigation={len(nav_titles)})"
+            f"{label}: count mismatch (book-config={len(book_items)}, navigation={len(nav_items)})"
         )
 
-    for i, (book_title, nav_title) in enumerate(zip(book_titles, nav_titles)):
-        if book_title != nav_title:
+    for i, (book_item, nav_item) in enumerate(zip(book_items, nav_items)):
+        if book_item.title != nav_item.title:
             errors.append(
-                f"{label}: title mismatch at index {i} (book-config={book_title!r}, navigation={nav_title!r})"
+                f"{label}: title mismatch at index {i} "
+                f"(book-config={book_item.title!r}, navigation={nav_item.title!r})"
+            )
+        if book_item.path != nav_item.path:
+            errors.append(
+                f"{label}: path mismatch at index {i} "
+                f"(book-config={book_item.path!r}, navigation={nav_item.path!r})"
             )
 
-    if len(book_titles) > len(nav_titles):
-        errors.append(f"{label}: extra in book-config: {book_titles[len(nav_titles):]!r}")
-    elif len(nav_titles) > len(book_titles):
-        errors.append(f"{label}: extra in navigation: {nav_titles[len(book_titles):]!r}")
+    if len(book_items) > len(nav_items):
+        errors.append(f"{label}: extra in book-config: {book_items[len(nav_items):]!r}")
+    elif len(nav_items) > len(book_items):
+        errors.append(f"{label}: extra in navigation: {nav_items[len(book_items):]!r}")
+
+    return errors
+
+
+def find_duplicates(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    duplicates: list[str] = []
+    for value in values:
+        if value in seen and value not in duplicates:
+            duplicates.append(value)
+        seen.add(value)
+    return duplicates
+
+
+def collect_pages() -> list[Page]:
+    candidates = [
+        Path("docs/index.md"),
+        *sorted(Path("docs/chapters").glob("*.md")),
+        *sorted(Path("docs/appendix").glob("*.md")),
+    ]
+    pages: list[Page] = []
+    for file_path in candidates:
+        if not file_path.exists():
+            continue
+        fm = parse_front_matter(file_path)
+        permalink = fm.get("permalink")
+        if isinstance(permalink, str) and permalink.strip():
+            pages.append(
+                Page(
+                    path=file_path,
+                    permalink=normalize_public_path(
+                        permalink, source=f"{file_path}:permalink"
+                    ),
+                    title=fm.get("title"),
+                )
+            )
+    return pages
+
+
+def validate_canonical_metadata(book: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    expected = {
+        "title": "要件から始めるソフトウェア設計（小規模TS Webアプリの実践）",
+        "description": "小〜中規模の TypeScript Web アプリを対象に、要件定義→設計→テストまでを一貫して学ぶ実践教材",
+        "author": "株式会社アイティードゥ",
+        "version": "0.1.0",
+        "language": "ja",
+        "license": "CC-BY-NC-SA-4.0",
+        "homepage": CANONICAL_HOMEPAGE,
+    }
+    for key, expected_value in expected.items():
+        actual = book.get(key)
+        if actual != expected_value:
+            errors.append(f"book-config.json: {key} must be {expected_value!r} (actual={actual!r})")
+
+    repository = book.get("repository")
+    if not isinstance(repository, dict):
+        errors.append("book-config.json: repository must be an object")
+    else:
+        if repository.get("url") != f"https://github.com/{REPOSITORY}.git":
+            errors.append("book-config.json: repository.url does not match canonical GitHub URL")
+        if repository.get("branch") != "main":
+            errors.append("book-config.json: repository.branch must be 'main'")
+
+    config = parse_scalar_block(Path("docs/_config.yml").read_text(encoding="utf-8"))
+    config_expected = {
+        "title": expected["title"],
+        "description": expected["description"],
+        "author": expected["author"],
+        "version": expected["version"],
+        "lang": expected["language"],
+        "license": expected["license"],
+        "url": "https://itdojp.github.io",
+        "baseurl": "/small-webapp-software-design-book",
+        "repository": REPOSITORY,
+        "homepage": CANONICAL_HOMEPAGE,
+    }
+    for key, expected_value in config_expected.items():
+        actual = config.get(key)
+        if actual != expected_value:
+            errors.append(f"docs/_config.yml: {key} must be {expected_value!r} (actual={actual!r})")
+
+    index_fm = parse_front_matter(Path("docs/index.md"))
+    index_expected = {
+        "title": expected["title"],
+        "description": expected["description"],
+        "author": expected["author"],
+        "version": expected["version"],
+        "permalink": "/",
+    }
+    for key, expected_value in index_expected.items():
+        actual = index_fm.get(key)
+        if actual != expected_value:
+            errors.append(f"docs/index.md: front matter {key} must be {expected_value!r} (actual={actual!r})")
+
+    return errors
+
+
+def validate_pages_and_assets(all_items: list[NavItem]) -> list[str]:
+    errors: list[str] = []
+    pages = collect_pages()
+    page_paths = [page.permalink for page in pages]
+    nav_paths = [item.path for item in all_items]
+
+    for dup in find_duplicates(page_paths):
+        errors.append(f"duplicate permalink: {dup}")
+    for dup in find_duplicates(nav_paths):
+        errors.append(f"duplicate navigation/config path: {dup}")
+
+    page_path_set = set(page_paths)
+    for item in all_items:
+        if item.path not in page_path_set:
+            errors.append(f"configured path has no page permalink: {item.path}")
+
+    listed_paths = set(nav_paths) | {"/"}
+    for page in pages:
+        if page.permalink not in listed_paths:
+            errors.append(f"page permalink is not listed in navigation/book-config: {page.path} -> {page.permalink}")
+
+    for page in pages:
+        fm = parse_front_matter(page.path)
+        for key in ("prev", "next"):
+            target = fm.get(key)
+            if isinstance(target, str) and target.strip():
+                normalized = normalize_public_path(target, source=f"{page.path}:{key}")
+                if normalized not in listed_paths:
+                    errors.append(f"{page.path}: {key} -> {normalized} is not a configured public path")
+
+    for asset in REQUIRED_ASSETS:
+        path = Path("docs") / asset
+        if not path.is_file() or path.stat().st_size == 0:
+            errors.append(f"required public asset is missing or empty: docs/{asset}")
 
     return errors
 
 
 def main() -> int:
-    book_path = Path("book-config.json")
-    nav_path = Path("docs/_data/navigation.yml")
-
     try:
-        book = load_json(book_path)
+        book = load_json(Path("book-config.json"))
         if not isinstance(book, dict):
-            raise ValueError("book-config.json must be a JSON object")
+            raise CheckError("book-config.json must be a JSON object")
 
         structure = book.get("structure")
         if not isinstance(structure, dict):
-            raise ValueError("book-config.json: structure must be an object")
+            raise CheckError("book-config.json: structure must be an object")
 
-        book_chapters = extract_titles(structure.get("chapters"), label="chapters")
-        book_appendices = extract_titles(structure.get("appendices"), label="appendices")
-
-        nav = parse_navigation_yaml(nav_path.read_text(encoding="utf-8"))
-        nav_chapters = [item.title for item in nav["chapters"]]
-        nav_appendices = [item.title for item in nav["appendices"]]
-    except ValueError as e:
+        book_chapters = collect_structure_items(structure.get("chapters"), label="chapters")
+        book_appendices = collect_structure_items(structure.get("appendices"), label="appendices")
+        nav = parse_navigation_yaml(Path("docs/_data/navigation.yml").read_text(encoding="utf-8"))
+    except (CheckError, json.JSONDecodeError) as e:
         sys.stderr.write(f"{e}\n")
         return 1
 
     errors: list[str] = []
+    errors.extend(validate_canonical_metadata(book))
     errors.extend(
-        compare_ordered_titles(
-            label="chapters", book_titles=book_chapters, nav_titles=nav_chapters
+        compare_ordered_items(
+            label="chapters", book_items=book_chapters, nav_items=nav["chapters"]
         )
     )
     errors.extend(
-        compare_ordered_titles(
-            label="appendices", book_titles=book_appendices, nav_titles=nav_appendices
+        compare_ordered_items(
+            label="appendices", book_items=book_appendices, nav_items=nav["appendices"]
         )
     )
+    errors.extend(validate_pages_and_assets([*book_chapters, *book_appendices]))
 
     if errors:
-        sys.stderr.write("book-config.json <-> navigation.yml consistency check failed:\n")
+        sys.stderr.write("book metadata/navigation consistency check failed:\n")
         for e in errors:
             sys.stderr.write(f"- {e}\n")
         return 1
 
     print(
-        f"OK: chapters={len(book_chapters)} appendices={len(book_appendices)} (titles+order match)"
+        "OK: metadata, navigation, permalinks, and required assets match "
+        f"(chapters={len(book_chapters)} appendices={len(book_appendices)})"
     )
     return 0
 


### PR DESCRIPTION
## Summary
- Add canonical homepage/path metadata to `book-config.json`, `docs/_config.yml`, and the published top page front matter.
- Expand `scripts/check_book_config_navigation_consistency.py` from title-order validation to a metadata, navigation, permalink, prev/next, path-safety, and required-assets gate.
- Wire the enhanced gate into Book QA and document the local verification commands in README.

## Why
The repository already checked the order of `book-config.json` and `docs/_data/navigation.yml`, but it did not fail on homepage drift, missing configured paths, unlisted published permalinks, invalid public paths, or missing core Pages assets. This PR makes those publication-critical assumptions explicit and CI-enforced.

## Validation
- `python3 -m py_compile scripts/check_book_config_navigation_consistency.py scripts/check_internal_links.py`
- `python3 scripts/check_book_config_navigation_consistency.py`
- `python3 scripts/check_internal_links.py`
- `BUNDLE_PATH=/home/devuser/work/CodeX/booksB/.codex-local/tmp/small-webapp-bundle bundle exec jekyll build --source docs --config docs/_config.yml --destination /home/devuser/work/CodeX/booksB/.codex-local/tmp/small-webapp-site-after`
- book-formatter pinned at `itdojp/book-formatter@da2a49e7d2dcd9e1fa885e910c458130fe8d73a4`: unicode, textlint, internal links, layout risk, markdown structure
- Negative fixtures: homepage drift and navigation-path drift failed as expected; CRLF front matter fixture passed
- `git diff --check`