### PR TITLE
Fix mobile sidebar closed state

### DIFF
--- a/docs/assets/css/mobile-responsive.css
+++ b/docs/assets/css/mobile-responsive.css
@@ -53,14 +53,21 @@ html {
     background: var(--bg-primary);
     border-right: 1px solid var(--border-color);
     box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
-    z-index: 1000;
-    transform: translateX(-100%);
-    transition: transform 0.3s ease;
+    /* Keep the drawer above the overlay while main.css is imported later. */
+    z-index: 999 !important;
+    /* Keep the closed drawer off-canvas despite later desktop sidebar rules. */
+    transform: translateX(-100%) !important;
+    visibility: hidden;
+    transition:
+      transform 0.3s ease,
+      visibility 0s linear 0.3s !important;
   }
 
   /* Show sidebar when toggled */
   .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar {
     transform: translateX(0) !important;
+    visibility: visible;
+    transition: transform 0.3s ease !important;
   }
   
   /* Ensure sidebar content is interactive */


### PR DESCRIPTION
## Summary
- Fix the mobile/tablet sidebar closed state so later `main.css` desktop sidebar rules cannot reopen the drawer at `<=1024px`.
- Keep the mobile drawer above the overlay (`999 > 950`) while preserving the backdrop.
- Add visibility gating and important transitions so the closed drawer is hidden/off-canvas and the opened drawer restores visibility.

## Issue
- Part of https://github.com/itdojp/it-engineer-knowledge-architecture/issues/168

## Verification
- `git diff --check`
- `python3 scripts/check_book_config_navigation_consistency.py`
- `python3 scripts/check_internal_links.py`
- `bundle exec jekyll build --source docs --config docs/_config.yml --destination /home/devuser/work/CodeX/booksB/.codex-local/serve/small-webapp-jekyll/small-webapp-software-design-book`
- Local visual checker: `books=1 pages=10 ok=10 warn=0 fail=0 globalWarn=0`
- Local z-index/visibility probe: 480 / 768 / 820 / 1024 px closed state is off-canvas and hidden; opened drawer is visible with `sidebarZ=999` above `overlayZ=950`; desktop content does not start under the sidebar.

## Notes
- This repository does not have a root `package.json`; local validation used the Jekyll/Pages build path, repository Python checks, and browser-based probes.
