### PR TITLE
公開導線に合わせUX module設定を修正

### DIFF
--- a/book-config.json
+++ b/book-config.json
@@ -111,10 +111,10 @@
     "modules": {
       "quickStart": false,
       "readingGuide": true,
-      "checklistPack": false,
+      "checklistPack": true,
       "troubleshootingFlow": false,
-      "conceptMap": true,
-      "figureIndex": true,
+      "conceptMap": false,
+      "figureIndex": false,
       "legalNotice": false,
       "glossary": true
     }


### PR DESCRIPTION
## 概要

Closes #119

公開Pagesとnavigationのreader-facing実体に合わせてUX flagsを修正します。

- 独立したAppendix Aを `checklistPack=true` として反映
- 専用実体がない `conceptMap` / `figureIndex` をfalseへ修正

## 検証

- metadata / navigation consistency
- internal links
- Jekyll build
- git diff --check

Profile C必須のconcept map欠損はportal側の別Issueで追跡し、本PRで実体を偽装しません。