### PR TITLE
chore: active workflowsをNode.js 24対応Actionへ更新

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -81,7 +81,7 @@ jobs:
           path: ${{ runner.temp }}/layout-risk-report.json
           if-no-files-found: ignore
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Build (Jekyll; GitHub Pages compatible)
         uses: actions/jekyll-build-pages@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Lint (markdownlint-cli2)
-        uses: DavidAnson/markdownlint-cli2-action@v19
+        uses: DavidAnson/markdownlint-cli2-action@v24
         with:
           config: .markdownlint.yml
           globs: |


### PR DESCRIPTION
## Summary
- Book QAの`actions/configure-pages`を`v5`からNode.js 24 runtime対応の`v6`へ更新
- CIの`DavidAnson/markdownlint-cli2-action`を`v19`からNode.js 24 runtime対応の`v24`へ更新
- workflow入力、permissions、Jekyll/markdownlint契約は維持

## Verification
- actionlint 1.7.12（変更2 workflow）: PASS
- `python3 scripts/check_book_config_navigation_consistency.py`: PASS
- `python3 scripts/check_internal_links.py`: PASS
- `bundle exec jekyll build --source docs --config docs/_config.yml --destination _site`: PASS
- `git diff --check`: PASS
- 対象旧参照: 0 / 新参照: 2

## Separated debt
- 既存Jekyll/Gem warningは#121で追跡中

Closes #124
